### PR TITLE
Using the non-minified JS and CSS files in bower.json:main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,8 +4,8 @@
   "location": "https://github.com/mbenford/ngTagsInput-bower",
   "homepage": "http://mbenford.github.io/ngTagsInput",
   "main": [
-    "ng-tags-input.min.js",
-    "ng-tags-input.min.css"
+    "ng-tags-input.js",
+    "ng-tags-input.css"
   ],
   "description": "Tags input directive for AngularJS",
   "dependencies": {


### PR DESCRIPTION
Changed bower.json:main so that it references non-minified files.

This meets the bower.json spec, which says that it should only include the non-minified files:
https://github.com/bower/bower.json-spec#main

(This fixes the issue I brought up here:)
https://github.com/mbenford/ngTagsInput/issues/441